### PR TITLE
Performance Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tests/*
 spot.js.old
+.DS_Store

--- a/spot.js
+++ b/spot.js
@@ -8,6 +8,7 @@
         spotRotateElem = document.getElementsByClassName("spot-rotate"),
         spotIndicatorElem = document.getElementsByClassName("spot-indicator"),
         indicatorOverlays = document.getElementsByClassName("spot-indicator-overlay"),
+
         spotShadowInstance = [],
         spotRotateInstance = [],
         spotIndicatorInstance = [],
@@ -19,8 +20,7 @@
             spotRotate: spotRotateElem,
             spotIndicator: spotIndicatorElem,
             spotArea: spotAreaElem
-        },
-        i;
+        };
 
     /* Minor configuration options for a maximum refresh per second and a controller for the shadows */
     var spotFPS = 60,
@@ -50,73 +50,124 @@
 
     /* Gets basic element info and calculates mouse-related variables */
     function SpotInstance(elem) {
+
+        var boundingClientRect = elem.getBoundingClientRect();
         this.elem = elem;
-        this.elemX = elem.getBoundingClientRect().left + (elem.offsetWidth / 2);
-        this.elemY = elem.getBoundingClientRect().top + (elem.offsetHeight / 2);
-        this.getRadians = function () {
+        this.elemX = boundingClientRect.left + (elem.offsetWidth / 2);
+        this.elemY = boundingClientRect.top + (elem.offsetHeight / 2);
+    }
+
+    SpotInstance.prototype = {
+        getRadians: function () {
             var rad = Math.atan2(this.elemY - mouseY, mouseX - this.elemX);
             return rad;
-        };
-        this.getAngle = function () {
+        },
+        getAngle: function () {
             var angle = -Math.round(this.getRadians() * 18000 / Math.PI) / 100;
             if (angle < 0) {
                 angle += 360;
             }
             return angle;
-        };
-        this.getDistance = function () {
+        },
+        getDistance: function () {
             var dist = Math.round(Math.sqrt(Math.pow(mouseX - this.elemX, 2) + Math.pow(this.elemY - mouseY, 2)));
             return dist;
-        };
-    }
+        }
+    };
 
     /* Creates new instances for each of the elements with a relevant selector */
     function createSpotInstances() {
-        for (i = 0; i < elems.spotIndicator.length; i += 1) {
-            spotIndicatorInstance[i] = new SpotInstance(elems.spotIndicator[i]);
+
+        var spotIndicator = elems.spotIndicator,
+            spotShadow = elems.spotShadow,
+            spotRotate = elems.spotRotate;
+
+        var spotIndicatorLength = spotIndicator.length,
+            spotShadowLength = spotShadow.length,
+            spotRotateLength = spotRotate.length,
+            instancesLength = spotIndicatorInstance.length;
+
+        var docFragment = document.createDocumentFragment(),
+            indicatorInstance,
+            boundingClientRect,
+            div;
+
+
+        for (var i = 0; i < spotIndicatorLength; i += 1) {
+            spotIndicatorInstance[i] = new SpotInstance(spotIndicator[i]);
         }
-        for (i = 0; i < elems.spotShadow.length; i += 1) {
-            spotShadowInstance[i] = new SpotInstance(elems.spotShadow[i]);
+        for (var i = 0; i < spotShadowLength; i += 1) {
+            spotShadowInstance[i] = new SpotInstance(spotShadow[i]);
         }
-        for (i = 0; i < elems.spotRotate.length; i += 1) {
-            spotRotateInstance[i] = new SpotInstance(elems.spotRotate[i]);
+        for (var i = 0; i < spotRotateLength; i += 1) {
+            spotRotateInstance[i] = new SpotInstance(spotRotate[i]);
         }
-        for (i = 0; i < spotIndicatorInstance.length; i += 1) {
-            indicator[i] = document.createElement("div");
-            indicator[i].className = "spot-indicator-overlay";
-            indicator[i].style.cssText = "display:table; position:absolute; pointer-events:none; left:" + (window.scrollX + spotIndicatorInstance[i].elem.getBoundingClientRect().left) + "px; top:" + (window.scrollY + spotIndicatorInstance[i].elem.getBoundingClientRect().top) + "px; height:" + spotIndicatorInstance[i].elem.offsetHeight + "px; width:" + spotIndicatorInstance[i].elem.offsetWidth + "px; color:white; text-align:center; font-weight:600; font-family:Arial; z-index:999999; outline:15px solid rgba(0,200,0,0.3); outline-offset:-15px; background:rgba(0,0,0,0.2);";
-            document.body.appendChild(indicator[i]);
+
+        for (var i = 0; i < instancesLength; i += 1) {
+
+            indicatorInstance = spotIndicatorInstance[i].elem;
+            boundingClientRect = indicatorInstance.getBoundingClientRect();
+
+            div = document.createElement("div");
+            div.className = "spot-indicator-overlay";
+            div.style.cssText = "display:table; position:absolute; pointer-events:none; left:" + (window.scrollX + boundingClientRect.left) + "px; top:" + (window.scrollY + boundingClientRect.top) + "px; height:" + indicatorInstance.offsetHeight + "px; width:" + indicatorInstance.offsetWidth + "px; color:white; text-align:center; font-weight:600; font-family:Arial; z-index:999999; outline:15px solid rgba(0,200,0,0.3); outline-offset:-15px; background:rgba(0,0,0,0.2);";
+            docFragment.appendChild(div);
+            indicator[i] = div;
         }
+        document.body.appendChild(docFragment);
     }
 
     /* Initiates the effects, this is tied to the mousemove event */
     function initiateSpotEffects(event) {
+
+        var spotShadowInstanceLength = spotShadowInstance.length,
+            spotRotateInstanceLength = spotRotateInstance.length;
+
+        var shadowInstance,
+            shadowInstanceStyle,
+            rotateInstance,
+            dropShadowText;
+
         getMousePosition(event);
-        for (i = 0; i < spotShadowInstance.length; i += 1) {
-            shadowDist[i] = Math.round(spotShadowInstance[i].getDistance() / shadowBlur);
-            if (spotShadowInstance[i].getDistance() > 15) {
-                spotShadowInstance[i].elem.style.webkitFilter = "drop-shadow(" + shadowDist[i] * -Math.round(Math.cos(spotShadowInstance[i].getRadians()) * 10) / 10 + "px " + shadowDist[i] * Math.round(Math.sin(spotShadowInstance[i].getRadians()) * 10) / 10 + "px " + shadowDist[i] + "px rgba(0,0,0,0.8))";
-                spotShadowInstance[i].elem.style.filter = "drop-shadow(" + shadowDist[i] * -Math.round(Math.cos(spotShadowInstance[i].getRadians()) * 10) / 10 + "px " + shadowDist[i] * Math.round(Math.sin(spotShadowInstance[i].getRadians()) * 10) / 10 + "px " + shadowDist[i] + "px rgba(0,0,0,0.8))";
+        for (var i = 0; i < spotShadowInstanceLength; i += 1) {
+
+            shadowInstance = spotShadowInstance[i];
+            shadowInstanceStyle = shadowInstance.elem.style;
+            shadowDist[i] = Math.round(shadowInstance.getDistance() / shadowBlur);
+
+            if (shadowInstance.getDistance() > 15) {
+                dropShadowText = "drop-shadow(" + shadowDist[i] * -Math.round(Math.cos(shadowInstance.getRadians()) * 10) / 10 + "px " + shadowDist[i] * Math.round(Math.sin(shadowInstance.getRadians()) * 10) / 10 + "px " + shadowDist[i] + "px rgba(0,0,0,0.8))";
+                shadowInstanceStyle.webkitFilter = dropShadowText;
+                shadowInstanceStyle.filter = dropShadowText;
             } else {
-                spotShadowInstance[i].elem.style.webkitFilter = "none";
-                spotShadowInstance[i].elem.style.filter = "none";
+                shadowInstanceStyle.webkitFilter = "none";
+                shadowInstanceStyle.filter = "none";
             }
         }
-        for (i = 0; i < spotRotateInstance.length; i += 1) {
-            spotRotateInstance[i].elem.style.transform = "rotate(" + spotRotateInstance[i].getAngle() + "deg)";
+        for (var i = 0; i < spotRotateInstanceLength; i += 1) {
+            rotateInstance = spotRotateInstance[i];
+            rotateInstance.elem.style.transform = "rotate(" + rotateInstance.getAngle() + "deg)";
         }
     }
 
     /* This is tied to the mousemove event */
     function updateIndicatorInfo() {
-        for (i = 0; i < spotIndicatorInstance.length; i += 1) {
-            indicator[i].innerHTML = spotIndicatorInstance[i].getDistance() + "px " + spotIndicatorInstance[i].getAngle() + "º";
+
+        var instanceLength = spotIndicatorInstance.length,
+            instance;
+
+        for (var i = 0; i < instanceLength; i += 1) {
+            instance = spotIndicatorInstance[i];
+            indicator[i].innerHTML = instance.getDistance() + "px " + instance.getAngle() + "º";
         }
     }
 
     /* Because we don't want new instances taking positions of already rotated elements */
     function clearAllEffects() {
-        for (i = 0; i < spotRotateInstance.length; i += 1) {
+
+        var instanceLength = spotRotateInstance.length;
+
+        for (var i = 0; i < instanceLength; i += 1) {
             spotRotateInstance[i].elem.style.transform = "rotate(0deg)";
         }
         while (indicatorOverlays[0]) {
@@ -126,7 +177,7 @@
 
     /* EVENT LISTENERS */
     if (elems.spotArea[0]) {
-        for (i = 0; i < elems.spotArea.length; i += 1) {
+        for (var i = 0; i < elems.spotArea.length; i += 1) {
             elems.spotArea[i].onmousemove = throttle(1000 / spotFPS, function (event) {
                 initiateSpotEffects(event);
                 updateIndicatorInfo();


### PR DESCRIPTION
- Caching lookup calls to local vars
- Caching `getBoundingClientRect()` and other calls to local vars
- Caching length in for-loops (constant lookups aren't free)
- Using `document.createDocumentFragment` to avoid constant reflows
- Moved several functions out of `SpotInstance` out of closure, into a Prototype

Most of these changes will give incremental improvements... but the
`documentFragments` and Prototype ones can help a lot.

`documentFragments` is the recommended way of appending multiple
things to the DOM, since they don't trigger reflow or repaints.

Using `Prototype` is convenient because every instance of `SpotInstance`
does not have its own definition on calculating radians, angle, or distance.
Instead, each instance will fallback to its prototype to call those
functions (and eventually up to Object.prototype).

Oh yeah, and I removed the `i` variable that was being shared everywhere.
While it may be convenient to not have to reinstantiate an `i` everywhere, it
can cause hard-to-find bugs if any for-loop ever needs to depend on one another.
